### PR TITLE
Fix: The modal of failed withdrawal cannot be closed.

### DIFF
--- a/src/pageComponents/WithdrawContent/WithdrawFooter/index.tsx
+++ b/src/pageComponents/WithdrawContent/WithdrawFooter/index.tsx
@@ -264,7 +264,7 @@ export default function WithdrawFooter({
   }, [clickSuccessOk]);
 
   const onClickFailed = useCallback(() => {
-    setIsSuccessModalOpen(false);
+    setIsFailModalOpen(false);
     clickFailedOk();
   }, [clickFailedOk]);
 


### PR DESCRIPTION
The modal of failed withdrawal cannot be closed. close #235 